### PR TITLE
fix: 안드로이드 아이콘 한자 표시 문제 해결

### DIFF
--- a/Frontend/commma/android/app/build.gradle
+++ b/Frontend/commma/android/app/build.gradle
@@ -117,3 +117,5 @@ dependencies {
         implementation jscFlavor
     }
 }
+
+apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"


### PR DESCRIPTION
## 이 PR이 하는 일
안드로이드 환경에서 아이콘이 한자로 표시되는 문제 해결

## 설명
안드로이드 build.gradle 파일 수정
