### PR TITLE
feat: 일기 작성 및 감정 선택 기능 통합 구현, 커스텀 디자인 알림 적용

### DIFF
--- a/Frontend/commma/components/CustomAlert.js
+++ b/Frontend/commma/components/CustomAlert.js
@@ -1,0 +1,204 @@
+// components/CustomAlert.js
+import React from 'react';
+import {
+    View,
+    Text,
+    TouchableOpacity,
+    Modal,
+    TouchableWithoutFeedback,
+} from 'react-native';
+import { StyleSheet } from 'react-native';
+import Icon from 'react-native-vector-icons/MaterialIcons';
+import customFont from '../styles/fonts';
+
+const CustomAlert = ({
+    visible,
+    title,
+    message,
+    buttons = [],
+    onBackdropPress,
+    type = 'default', // 'success', 'warning', 'error'
+}) => {
+    const getIconName = () => {
+        switch (type) {
+            case 'success': return 'check-circle';
+            case 'warning': return 'warning';
+            case 'error': return 'error';
+            default: return 'info';
+        }
+    };
+
+    const getIconColor = () => {
+        switch (type) {
+            case 'success': return '#4CAF50';
+            case 'warning': return '#FF9800';
+            case 'error': return '#F44336';
+            default: return '#2196F3';
+        }
+    };
+
+    // 버튼이 3개 이상이면 세로 배치, 2개 이하면 가로 배치
+    const shouldUseVerticalLayout = buttons.length > 2;
+
+    return (
+        <Modal
+            animationType="fade"
+            transparent={true}
+            visible={visible}
+            onRequestClose={() => {
+                if (onBackdropPress) onBackdropPress();
+            }}
+        >
+            <TouchableWithoutFeedback onPress={onBackdropPress}>
+                <View style={styles.backdrop}>
+                    <TouchableWithoutFeedback>
+                        <View style={styles.alertContainer}>
+                            {/* 아이콘 */}
+                            <View style={styles.iconContainer}>
+                                <Icon
+                                    name={getIconName()}
+                                    size={48}
+                                    color={getIconColor()}
+                                />
+                            </View>
+
+                            {/* 제목 */}
+                            {title && (
+                                <Text style={styles.title}>{title}</Text>
+                            )}
+
+                            {/* 메시지 */}
+                            {message && (
+                                <Text style={styles.message}>{message}</Text>
+                            )}
+
+                            {/* 버튼들 - 동적 레이아웃 */}
+                            <View style={[
+                                styles.buttonsContainer,
+                                shouldUseVerticalLayout && styles.buttonsContainerVertical
+                            ]}>
+                                {buttons.map((button, index) => (
+                                    <TouchableOpacity
+                                        key={index}
+                                        style={[
+                                            styles.button,
+                                            button.style === 'cancel' && styles.cancelButton,
+                                            button.style === 'destructive' && styles.destructiveButton,
+                                            shouldUseVerticalLayout && styles.buttonVertical,
+                                            buttons.length === 1 && styles.singleButton,
+                                        ]}
+                                        onPress={button.onPress}
+                                    >
+                                        <Text
+                                            style={[
+                                                styles.buttonText,
+                                                button.style === 'cancel' && styles.cancelButtonText,
+                                                button.style === 'destructive' && styles.destructiveButtonText,
+                                            ]}
+                                        >
+                                            {button.text}
+                                        </Text>
+                                    </TouchableOpacity>
+                                ))}
+                            </View>
+                        </View>
+                    </TouchableWithoutFeedback>
+                </View>
+            </TouchableWithoutFeedback>
+        </Modal>
+    );
+};
+
+const styles = StyleSheet.create({
+    backdrop: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    },
+    alertContainer: {
+        backgroundColor: '#FFFFFF',
+        borderRadius: 20,
+        padding: 24,
+        minWidth: 280,
+        maxWidth: 340,
+        shadowColor: '#000',
+        shadowOffset: {
+            width: 0,
+            height: 4,
+        },
+        shadowOpacity: 0.25,
+        shadowRadius: 8,
+        elevation: 12,
+    },
+    iconContainer: {
+        alignItems: 'center',
+        marginBottom: 16,
+    },
+    title: {
+        fontSize: 20,
+        fontWeight: 'bold',
+        color: '#333333',
+        textAlign: 'center',
+        marginBottom: 12,
+        lineHeight: 24,
+        fontFamily: customFont,
+    },
+    message: {
+        fontSize: 16,
+        color: '#666666',
+        textAlign: 'center',
+        marginBottom: 24,
+        lineHeight: 22,
+        fontFamily: customFont,
+    },
+    buttonsContainer: {
+        flexDirection: 'row',
+        gap: 12,
+    },
+    buttonsContainerVertical: {
+        flexDirection: 'column',
+        gap: 8,
+    },
+    button: {
+        flex: 1,
+        backgroundColor: '#FB644C',
+        borderRadius: 12,
+        paddingVertical: 12,
+        paddingHorizontal: 16,
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: 44,
+    },
+    buttonVertical: {
+        flex: 0,
+        width: '100%',
+        paddingVertical: 14,
+    },
+    singleButton: {
+        flex: 1,
+    },
+    cancelButton: {
+        backgroundColor: '#F5F5F5',
+        borderWidth: 1,
+        borderColor: '#E0E0E0',
+    },
+    destructiveButton: {
+        backgroundColor: '#F44336',
+    },
+    buttonText: {
+        color: '#FFFFFF',
+        fontSize: 16,
+        fontWeight: '600',
+        fontFamily: customFont,
+        textAlign: 'center',
+    },
+    cancelButtonText: {
+        color: '#666666',
+    },
+    destructiveButtonText: {
+        color: '#FFFFFF',
+    },
+});
+
+export default CustomAlert;

--- a/Frontend/commma/components/EmotionModal.js
+++ b/Frontend/commma/components/EmotionModal.js
@@ -14,6 +14,8 @@ import Icon from 'react-native-vector-icons/MaterialIcons';
 import EmotionGrid from './EmotionGrid';
 import { emotions } from '../data/emotionsData';
 import { emotionModalStyles } from '../styles/components/EmotionModalStyles';
+import CustomAlert from './CustomAlert';
+import { useCustomAlert } from '../hooks/useCustomAlert';
 
 const EmotionModal = ({
     visible,
@@ -28,6 +30,7 @@ const EmotionModal = ({
     cardAnimations,
     onClose,
 }) => {
+    const { alertConfig, showAlert, hideAlert } = useCustomAlert();
     // 감정 애니메이션 초기화
     const resetEmotionAnimations = () => {
         cardAnimations.forEach(anim => {
@@ -89,7 +92,12 @@ const EmotionModal = ({
     // 감정 적용
     const applyEmotion = () => {
         if (!selectedEmotion || !selectedText.trim()) {
-            Alert.alert('오류', '감정과 텍스트를 선택해주세요.');
+            showAlert({
+                title: '오류',
+                message: '감정과 텍스트를 선택해주세요.',
+                type: 'warning',
+                buttons: [{ text: '확인', onPress: hideAlert }]
+            });
             return;
         }
 
@@ -99,14 +107,15 @@ const EmotionModal = ({
         );
 
         if (overlappingSegments.length > 0 && !isEditingEmotion) {
-            Alert.alert(
-                '기존 감정 삭제',
-                '이미 감정이 선택된 부분이 있습니다. 기존의 감정은 삭제됩니다. 진행하시겠습니까?',
-                [
-                    { text: '취소', style: 'cancel' },
-                    { text: '확인', onPress: saveEmotionReplace },
+            showAlert({
+                title: '기존 감정 삭제',
+                message: '이미 감정이 선택된 부분이 있습니다. 기존의 감정은 삭제됩니다. 진행하시겠습니까?',
+                type: 'warning',
+                buttons: [
+                    { text: '취소', style: 'cancel', onPress: hideAlert },
+                    { text: '확인', onPress: () => { hideAlert(); saveEmotionReplace(); } }
                 ]
-            );
+            });
             return;
         } else {
             saveEmotionReplace();
@@ -140,21 +149,23 @@ const EmotionModal = ({
 
     // 감정 삭제
     const deleteEmotion = () => {
-        Alert.alert(
-            '감정 제거',
-            '정말 감정을 제거하시겠습니까?',
-            [
-                { text: '취소', style: 'cancel' },
+        showAlert({
+            title: '감정 제거',
+            message: '정말 감정을 제거하시겠습니까?',
+            type: 'warning',
+            buttons: [
+                { text: '취소', style: 'cancel', onPress: hideAlert },
                 {
                     text: '제거',
                     style: 'destructive',
                     onPress: () => {
+                        hideAlert();
                         setEmotionSegments(prev => prev.filter(segment => segment.id !== editingSegmentId));
                         closeModal();
                     }
                 }
             ]
-        );
+        });
     };
 
     const closeModal = () => {
@@ -164,90 +175,102 @@ const EmotionModal = ({
     };
 
     return (
-        <Modal
-            animationType="slide"
-            transparent={true}
-            visible={visible}
-            onRequestClose={closeModal}
-        >
-            <TouchableWithoutFeedback onPress={closeModal}>
-                <View style={emotionModalStyles.modalOverlay}>
-                    <TouchableWithoutFeedback>
-                        <View style={emotionModalStyles.modalContainer}>
-                            {/* 헤더 */}
-                            <View style={emotionModalStyles.modalHeader}>
-                                <Text style={emotionModalStyles.modalTitle}>
-                                    {isEditingEmotion ? '감정 수정하기' : '이 문장에 대한 감정 선택'}
-                                </Text>
-                                <TouchableOpacity onPress={closeModal}>
-                                    <Icon name="close" size={24} color="#666666" />
-                                </TouchableOpacity>
-                            </View>
-
-                            {/* 선택된 텍스트 */}
-                            <View style={emotionModalStyles.selectedTextContainer}>
-                                <Text style={emotionModalStyles.selectedTextLabel}>선택된 문장:</Text>
-                                <Text style={emotionModalStyles.selectedTextDisplay}>"{selectedText}"</Text>
-                            </View>
-
-                            {/* 감정 그리드 */}
-                            <EmotionGrid
-                                selectedEmotion={selectedEmotion}
-                                onEmotionSelect={handleEmotionSelect}
-                                cardAnimations={cardAnimations}
-                            />
-
-                            {/* 선택된 감정 미리보기 */}
-                            {selectedEmotion && (
-                                <View style={emotionModalStyles.selectedEmotionInfo}>
-                                    <View style={[
-                                        emotionModalStyles.selectedEmotionPreview,
-                                        { backgroundColor: selectedEmotion.color }
-                                    ]}>
-                                        <Text style={emotionModalStyles.selectedEmotionName}>
-                                            {selectedEmotion.name}
-                                        </Text>
-                                    </View>
-                                </View>
-                            )}
-
-                            {/* 버튼들 */}
-                            <View style={emotionModalStyles.modalButtons}>
-                                <TouchableOpacity
-                                    style={emotionModalStyles.cancelButton}
-                                    onPress={closeModal}
-                                >
-                                    <Text style={emotionModalStyles.cancelButtonText}>취소</Text>
-                                </TouchableOpacity>
-
-                                {isEditingEmotion && (
-                                    <TouchableOpacity
-                                        style={emotionModalStyles.deleteButton}
-                                        onPress={deleteEmotion}
-                                    >
-                                        <Icon name="delete" size={16} color="#FFFFFF" />
-                                        <Text style={emotionModalStyles.deleteButtonText}>삭제</Text>
+        <>
+            <Modal
+                animationType="slide"
+                transparent={true}
+                visible={visible}
+                onRequestClose={closeModal}
+            >
+                <TouchableWithoutFeedback onPress={closeModal}>
+                    <View style={emotionModalStyles.modalOverlay}>
+                        <TouchableWithoutFeedback>
+                            <View style={emotionModalStyles.modalContainer}>
+                                {/* 헤더 */}
+                                <View style={emotionModalStyles.modalHeader}>
+                                    <Text style={emotionModalStyles.modalTitle}>
+                                        {isEditingEmotion ? '감정 수정하기' : '이 문장에 대한 감정 선택'}
+                                    </Text>
+                                    <TouchableOpacity onPress={closeModal}>
+                                        <Icon name="close" size={24} color="#666666" />
                                     </TouchableOpacity>
+                                </View>
+
+                                {/* 선택된 텍스트 */}
+                                <View style={emotionModalStyles.selectedTextContainer}>
+                                    <Text style={emotionModalStyles.selectedTextLabel}>선택된 문장:</Text>
+                                    <Text style={emotionModalStyles.selectedTextDisplay}>"{selectedText}"</Text>
+                                </View>
+
+                                {/* 감정 그리드 */}
+                                <EmotionGrid
+                                    selectedEmotion={selectedEmotion}
+                                    onEmotionSelect={handleEmotionSelect}
+                                    cardAnimations={cardAnimations}
+                                />
+
+                                {/* 선택된 감정 미리보기 */}
+                                {selectedEmotion && (
+                                    <View style={emotionModalStyles.selectedEmotionInfo}>
+                                        <View style={[
+                                            emotionModalStyles.selectedEmotionPreview,
+                                            { backgroundColor: selectedEmotion.color }
+                                        ]}>
+                                            <Text style={emotionModalStyles.selectedEmotionName}>
+                                                {selectedEmotion.name}
+                                            </Text>
+                                        </View>
+                                    </View>
                                 )}
 
-                                <TouchableOpacity
-                                    style={[
-                                        emotionModalStyles.applyButton,
-                                        !selectedEmotion && emotionModalStyles.applyButtonDisabled
-                                    ]}
-                                    onPress={applyEmotion}
-                                    disabled={!selectedEmotion}
-                                >
-                                    <Text style={emotionModalStyles.applyButtonText}>
-                                        {isEditingEmotion ? '수정' : '적용'}
-                                    </Text>
-                                </TouchableOpacity>
+                                {/* 버튼들 */}
+                                <View style={emotionModalStyles.modalButtons}>
+                                    <TouchableOpacity
+                                        style={emotionModalStyles.cancelButton}
+                                        onPress={closeModal}
+                                    >
+                                        <Text style={emotionModalStyles.cancelButtonText}>취소</Text>
+                                    </TouchableOpacity>
+
+                                    {isEditingEmotion && (
+                                        <TouchableOpacity
+                                            style={emotionModalStyles.deleteButton}
+                                            onPress={deleteEmotion}
+                                        >
+                                            <Icon name="delete" size={16} color="#FFFFFF" />
+                                            <Text style={emotionModalStyles.deleteButtonText}>삭제</Text>
+                                        </TouchableOpacity>
+                                    )}
+
+                                    <TouchableOpacity
+                                        style={[
+                                            emotionModalStyles.applyButton,
+                                            !selectedEmotion && emotionModalStyles.applyButtonDisabled
+                                        ]}
+                                        onPress={applyEmotion}
+                                        disabled={!selectedEmotion}
+                                    >
+                                        <Text style={emotionModalStyles.applyButtonText}>
+                                            {isEditingEmotion ? '수정' : '적용'}
+                                        </Text>
+                                    </TouchableOpacity>
+                                </View>
                             </View>
-                        </View>
-                    </TouchableWithoutFeedback>
-                </View>
-            </TouchableWithoutFeedback>
-        </Modal>
+                        </TouchableWithoutFeedback>
+                    </View>
+                </TouchableWithoutFeedback>
+            </Modal>
+
+            {/* 커스텀 Alert 추가 */}
+            <CustomAlert
+                visible={alertConfig.visible}
+                title={alertConfig.title}
+                message={alertConfig.message}
+                buttons={alertConfig.buttons}
+                type={alertConfig.type}
+                onBackdropPress={hideAlert}
+            />
+        </>
     );
 };
 

--- a/Frontend/commma/components/TextSelector.js
+++ b/Frontend/commma/components/TextSelector.js
@@ -1,24 +1,40 @@
 // components/TextSelector.js
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import {
     View,
     Text,
     TextInput,
     ScrollView,
-    TouchableOpacity,
 } from 'react-native';
 import { textSelectorStyles } from '../styles/TextSelectorStyles';
 
 const TextSelector = ({ 
-    content, 
+    content1, 
     emotionSegments, 
-    onSelectionChange, 
+    onSelectionChangeCallBack, 
+    onContentChange,
     onEditEmotion 
 }) => {
-    const textInputRef = useRef(null);
+    const [content, setContent] = useState(content1);
+
+    // content 변경 처리 (비동기 처리 지원)
+    const handleContentChange = async (text) => {
+        if (onContentChange) {
+            const shouldUpdate = await onContentChange(text);
+            if (shouldUpdate !== false) {
+                setContent(text);
+            }
+        } else {
+            setContent(text);
+        }
+    };
 
     // 스타일된 텍스트 렌더링
-    const renderStyledText = () => {
+    const renderStyledText = (content) => {
+        if (!content || content.length === 0) {
+            return null;
+        }
+
         if (emotionSegments.length === 0) {
             return (
                 <Text style={textSelectorStyles.styledText}>
@@ -93,19 +109,34 @@ const TextSelector = ({
                 contentContainerStyle={textSelectorStyles.scrollContent}
             >
                 <View style={textSelectorStyles.hybridContainer}>
+                    {/* 감정 표시용 오버레이 */}
                     <View style={textSelectorStyles.styledOverlay}>
-                        {renderStyledText()}
+                        {renderStyledText(content)}
                     </View>
+                    
+                    {/* 투명한 TextInput - 실제 입력 처리 */}
                     <TextInput
-                        ref={textInputRef}
-                        style={textSelectorStyles.hybridInput}
+                        style={[
+                            textSelectorStyles.hybridInput,
+                            { 
+                                color: content && content.length > 0 ? 'transparent' : '#999999' 
+                            }
+                        ]}
                         multiline
                         value={content}
-                        onSelectionChange={onSelectionChange}
+                        onSelectionChange={(event) => {
+                            onSelectionChangeCallBack({
+                                start: event.nativeEvent.selection.start, 
+                                end: event.nativeEvent.selection.end, 
+                                content: content
+                            });
+                        }}
+                        onChangeText={handleContentChange}
                         textAlignVertical="top"
-                        selectionColor="#FB644C"
-                        showSoftInputOnFocus={false}
+                        selectionColor="#E57373"
                         scrollEnabled={false}
+                        placeholder="여기에 일기를 작성해보세요..."
+                        placeholderTextColor="#999999"
                     />
                 </View>
             </ScrollView>

--- a/Frontend/commma/hooks/useCustomAlert.js
+++ b/Frontend/commma/hooks/useCustomAlert.js
@@ -1,0 +1,32 @@
+// hooks/useCustomAlert.js
+import { useState } from 'react';
+
+export const useCustomAlert = () => {
+    const [alertConfig, setAlertConfig] = useState({
+        visible: false,
+        title: '',
+        message: '',
+        buttons: [],
+        type: 'default',
+    });
+
+    const showAlert = (config) => {
+        setAlertConfig({
+            ...config,
+            visible: true,
+        });
+    };
+
+    const hideAlert = () => {
+        setAlertConfig(prev => ({
+            ...prev,
+            visible: false,
+        }));
+    };
+
+    return {
+        alertConfig,
+        showAlert,
+        hideAlert,
+    };
+};

--- a/Frontend/commma/pages/DiaryDetail.js
+++ b/Frontend/commma/pages/DiaryDetail.js
@@ -35,7 +35,7 @@ const DiaryDetail = ({ navigation, route }) => {
 
         const sortedSegments = [...diary.emotionSegments].sort((a, b) => a.start - b.start);
         const charEmotions = new Array(diary.content.length).fill(null);
-        
+
         sortedSegments.forEach(segment => {
             for (let i = segment.start; i < segment.end; i++) {
                 if (i < diary.content.length) {
@@ -95,16 +95,19 @@ const DiaryDetail = ({ navigation, route }) => {
         <SafeAreaView style={diaryDetailStyles.container}>
             {/* 헤더 */}
             <View style={diaryDetailStyles.header}>
-                <TouchableOpacity 
+                <TouchableOpacity
                     style={diaryDetailStyles.backButton}
                     onPress={() => navigation.goBack()}
                 >
                     <Icon name="arrow-back" size={24} color="#333333" />
                 </TouchableOpacity>
 
-                <TouchableOpacity 
+                <TouchableOpacity
                     style={diaryDetailStyles.editButton}
-                    onPress={() => navigation.navigate('DiaryEditor', { diary })}
+                    onPress={() => navigation.navigate('EmotionSelector', {
+                        diary: diary,
+                        isEditing: true
+                    })}
                 >
                     <Icon name="edit" size={20} color="#FFFFFF" />
                 </TouchableOpacity>
@@ -137,9 +140,9 @@ const DiaryDetail = ({ navigation, route }) => {
                 {diary.emotionSegments && diary.emotionSegments.length > 0 && (
                     <View style={diaryDetailStyles.emotionStats}>
                         <Text style={diaryDetailStyles.emotionStatsTitle}>
-                            감정 분석 ({diary.emotionSegments.length}개)
+                            선택된 감정 ({diary.emotionSegments.length}개)
                         </Text>
-                        
+
                         {diary.emotionSegments
                             .sort((a, b) => a.start - b.start)
                             .map((segment) => (

--- a/Frontend/commma/pages/MyPage.js
+++ b/Frontend/commma/pages/MyPage.js
@@ -1,41 +1,61 @@
+// MyPage.js
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, Alert } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
+import CustomAlert from '../components/CustomAlert';
+import { useCustomAlert } from '../hooks/useCustomAlert';
 
 const MyPage = ({ route }) => {
   const navigation = useNavigation();
   const { onLogout } = route.params || {};
 
+  const { alertConfig, showAlert, hideAlert } = useCustomAlert();
+
   const handleLogout = () => {
-    Alert.alert(
-      '로그아웃',
-      '정말 로그아웃하시겠습니까?',
-      [
+    showAlert({
+      title: '로그아웃',
+      message: '정말 로그아웃하시겠습니까?',
+      type: 'warning',
+      buttons: [
         {
           text: '취소',
           style: 'cancel',
+          onPress: hideAlert,
         },
         {
           text: '로그아웃',
           onPress: () => {
+            hideAlert();
             if (onLogout) {
               onLogout();
             }
           },
         },
-      ],
-    );
+      ]
+    });
   };
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>마이페이지</Text>
-      <Text style={styles.subtitle}>프로필과 설정을 관리하세요</Text>
-      
-      <TouchableOpacity style={styles.logoutButton} onPress={handleLogout}>
-        <Text style={styles.logoutText}>로그아웃</Text>
-      </TouchableOpacity>
-    </View>
+    <>
+      <View style={styles.container}>
+        <Text style={styles.title}>마이페이지</Text>
+        <Text style={styles.subtitle}>프로필과 설정을 관리하세요</Text>
+        
+        <TouchableOpacity style={styles.logoutButton} onPress={handleLogout}>
+          <Text style={styles.logoutText}>로그아웃</Text>
+        </TouchableOpacity>
+      </View>
+
+      {/* 커스텀 Alert 추가 */}
+      <CustomAlert
+        visible={alertConfig.visible}
+        title={alertConfig.title}
+        message={alertConfig.message}
+        buttons={alertConfig.buttons}
+        type={alertConfig.type}
+        onBackdropPress={hideAlert}
+      />
+    </>
   );
 };
 

--- a/Frontend/commma/pages/OnboardingScreen.js
+++ b/Frontend/commma/pages/OnboardingScreen.js
@@ -12,12 +12,15 @@ import {
 } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import customFont from '../styles/fonts';
+import CustomAlert from '../components/CustomAlert';
+import { useCustomAlert } from '../hooks/useCustomAlert';
 
 const { width, height } = Dimensions.get('window');
 
 const OnboardingScreen = ({ onComplete, userEmail }) => {
   const [currentStep, setCurrentStep] = useState(0);
   const [userName, setUserName] = useState('');
+  const { alertConfig, showAlert, hideAlert } = useCustomAlert();
   const fadeAnim = useRef(new Animated.Value(0)).current;
   const scaleAnim = useRef(new Animated.Value(0.8)).current;
   const highlightAnim = useRef(new Animated.Value(0)).current;
@@ -167,7 +170,12 @@ const OnboardingScreen = ({ onComplete, userEmail }) => {
     if (currentStep === 0) {
       // 첫 번째 단계에서 이름 설정 API 호출
       if (!userName.trim()) {
-        Alert.alert('알림', '이름을 입력해주세요.');
+        showAlert({
+          title: '알림',
+          message: '이름을 입력해주세요.',
+          type: 'warning',
+          buttons: [{ text: '확인', onPress: hideAlert }]
+        });
         return;
       }
       
@@ -248,7 +256,12 @@ const OnboardingScreen = ({ onComplete, userEmail }) => {
   
       if (!emailToUse) {
         console.error('❌ [OnboardingScreen] 이메일을 찾을 수 없음');
-        Alert.alert('오류', '이메일 정보를 찾을 수 없습니다.');
+        showAlert({
+          title: '오류',
+          message: '이메일 정보를 찾을 수 없습니다.',
+          type: 'error',
+          buttons: [{ text: '확인', onPress: hideAlert }]
+        });
         return;
       }
   
@@ -275,10 +288,15 @@ const OnboardingScreen = ({ onComplete, userEmail }) => {
       }
     } catch (error) {
       console.error('❌ [OnboardingScreen] 네트워크 오류:', error);
-      Alert.alert('오류', '이름 설정에 실패했습니다. 계속 진행하시겠습니까?', [
-        { text: '다시 시도', style: 'cancel' },
-        { text: '계속 진행', onPress: () => {} }
-      ]);
+      showAlert({
+        title: '오류',
+        message: '이름 설정에 실패했습니다. 계속 진행하시겠습니까?',
+        type: 'warning',
+        buttons: [
+          { text: '다시 시도', style: 'cancel', onPress: hideAlert },
+          { text: '계속 진행', onPress: hideAlert }
+        ]
+      });
     }
   };
 
@@ -673,6 +691,7 @@ const OnboardingScreen = ({ onComplete, userEmail }) => {
   };
 
   return (
+    <>
     <View style={styles.container}>
       <View style={styles.content}>
         {renderAnimation()}
@@ -714,6 +733,16 @@ const OnboardingScreen = ({ onComplete, userEmail }) => {
         </View>
       )}
     </View>
+    {/* 커스텀 Alert 추가 */}
+      <CustomAlert
+        visible={alertConfig.visible}
+        title={alertConfig.title}
+        message={alertConfig.message}
+        buttons={alertConfig.buttons}
+        type={alertConfig.type}
+        onBackdropPress={hideAlert}
+      />
+      </>
   );
 };
 

--- a/Frontend/commma/pages/Write.js
+++ b/Frontend/commma/pages/Write.js
@@ -35,7 +35,7 @@ const Write = ({ navigation }) => {
         const unsubscribe = navigation.addListener('focus', () => {
             loadDiaries();
         });
-        
+
         return unsubscribe;
     }, [navigation, loadDiaries]);
 
@@ -100,7 +100,10 @@ const Write = ({ navigation }) => {
                 <Text style={writeStyles.headerTitle}>내 일기</Text>
                 <TouchableOpacity
                     style={writeStyles.writeButton}
-                    onPress={() => navigation.navigate('DiaryEditor')}
+                    onPress={() => navigation.navigate('EmotionSelector', {
+                        diary: {},
+                        isEditing: false
+                    })}
                 >
                     <Icon name="add" size={24} color="#FFFFFF" />
                 </TouchableOpacity>
@@ -115,7 +118,10 @@ const Write = ({ navigation }) => {
                         <Text style={writeStyles.emptySubtitle}>첫 번째 일기를 작성해보세요!</Text>
                         <TouchableOpacity
                             style={writeStyles.emptyWriteButton}
-                            onPress={() => navigation.navigate('DiaryEditor')}
+                            onPress={() => navigation.navigate('EmotionSelector', {
+                                diary: {},
+                                isEditing: false
+                            })}
                         >
                             <Text style={writeStyles.emptyWriteButtonText}>일기 쓰기</Text>
                         </TouchableOpacity>
@@ -139,7 +145,10 @@ const Write = ({ navigation }) => {
                                         </View>
                                     )}
                                     <TouchableOpacity
-                                        onPress={() => navigation.navigate('DiaryEditor', { diary })}
+                                        onPress={() => navigation.navigate('EmotionSelector', {
+                                            diary: diary,
+                                            isEditing: true
+                                        })}
                                         style={writeStyles.actionButton}
                                     >
                                         <Icon name="edit" size={18} color="#666666" />
@@ -152,11 +161,11 @@ const Write = ({ navigation }) => {
                                     </TouchableOpacity>
                                 </View>
                             </View>
-                            
+
                             <Text style={writeStyles.diaryTitle} numberOfLines={1}>
                                 {diary.title || '제목 없음'}
                             </Text>
-                            
+
                             <Text style={writeStyles.diaryPreview} numberOfLines={3}>
                                 {getPreviewText(diary.content)}
                             </Text>

--- a/Frontend/commma/styles/DiaryDetailStyles.js
+++ b/Frontend/commma/styles/DiaryDetailStyles.js
@@ -42,12 +42,12 @@ export const diaryDetailStyles = StyleSheet.create({
         paddingVertical: 20,
     },
     dateText: {
-        fontSize: 26,
+        fontSize: 35,
         color: '#FB644C',
         fontFamily: customFont,
     },
     updatedText: {
-        fontSize: 14,
+        fontSize: 18,
         color: '#999999',
         marginTop: 4,
         fontFamily: customFont,
@@ -67,7 +67,7 @@ export const diaryDetailStyles = StyleSheet.create({
         paddingVertical: 20,
     },
     contentText: {
-        fontSize: 18,
+        fontSize: 20,
         lineHeight: 24,
         color: '#333333',
         fontFamily: customFont,
@@ -87,6 +87,7 @@ export const diaryDetailStyles = StyleSheet.create({
     emotionItem: {
         flexDirection: 'row',
         alignItems: 'flex-start',
+        justifyContent: 'center',
         marginBottom: 12,
         backgroundColor: '#FAFAFA',
         padding: 12,
@@ -102,7 +103,7 @@ export const diaryDetailStyles = StyleSheet.create({
     },
     emotionIndicatorText: {
         color: '#FFFFFF',
-        fontSize: 13,
+        fontSize: 18,
         textShadowColor: 'rgba(0,0,0,0.3)',
         textShadowOffset: { width: 0, height: 1 },
         textShadowRadius: 1,
@@ -110,7 +111,7 @@ export const diaryDetailStyles = StyleSheet.create({
     },
     emotionText: {
         flex: 1,
-        fontSize: 16,
+        fontSize: 18,
         color: '#333333',
         lineHeight: 20,
         fontFamily: customFont,

--- a/Frontend/commma/styles/EmotionSelectorStyles.js
+++ b/Frontend/commma/styles/EmotionSelectorStyles.js
@@ -47,7 +47,7 @@ export const emotionSelectorStyles = StyleSheet.create({
         fontFamily: customFont,
     },
     subtitle: {
-        fontSize: 16,
+        fontSize: 18,
         color: '#FB644C',
         fontFamily: customFont,
     },
@@ -80,7 +80,7 @@ export const emotionSelectorStyles = StyleSheet.create({
     },
     statsCountText: {
         color: '#FFFFFF',
-        fontSize: 16,
+        fontSize: 18,
         fontFamily: customFont,
     },
     statsList: {
@@ -127,7 +127,7 @@ export const emotionSelectorStyles = StyleSheet.create({
         fontFamily: customFont,
     },
     statsPosition: {
-        fontSize: 13,
+        fontSize: 15,
         color: '#999999',
         fontFamily: customFont,
     },
@@ -178,5 +178,24 @@ export const emotionSelectorStyles = StyleSheet.create({
         fontSize: 16,
         marginLeft: 6,
         fontFamily: customFont,
+    },
+    titleInputContainer: {
+        paddingHorizontal: 20,
+        paddingVertical: 15,
+        borderBottomWidth: 1,
+        borderBottomColor: '#F0F0F0',
+        backgroundColor: '#FFFFFF',
+    },
+    titleInput: {
+        fontSize: 25,
+        color: '#333333',
+        fontFamily: customFont,
+        paddingVertical: 8,
+        paddingHorizontal: 0,
+    },
+    subtitleContainer: {
+        paddingHorizontal: 20,
+        paddingVertical: 12,
+        backgroundColor: '#FAFAFA',
     },
 });

--- a/Frontend/commma/styles/TextSelectorStyles.js
+++ b/Frontend/commma/styles/TextSelectorStyles.js
@@ -26,15 +26,15 @@ export const textSelectorStyles = StyleSheet.create({
         left: 0,
         right: 0,
         bottom: 0,
-        zIndex: 1,
-        color: 'transparent',
-        fontSize: 16,
+        zIndex: 2, // 위쪽 레이어
+        fontSize: 20,
         lineHeight: 24,
         textAlignVertical: 'top',
         backgroundColor: 'transparent',
         paddingHorizontal: 0,
         paddingVertical: 0,
         margin: 0,
+        fontFamily: customFont,
     },
     styledOverlay: {
         position: 'absolute',
@@ -42,7 +42,7 @@ export const textSelectorStyles = StyleSheet.create({
         left: 0,
         right: 0,
         bottom: 0,
-        zIndex: 2,
+        zIndex: 1, // 아래쪽 레이어
         backgroundColor: 'transparent',
         pointerEvents: 'none',
         paddingHorizontal: 0,
@@ -50,11 +50,12 @@ export const textSelectorStyles = StyleSheet.create({
         margin: 0,
     },
     styledText: {
-        fontSize: 16,
+        fontSize: 20,
         lineHeight: 24,
         color: '#333333',
         paddingHorizontal: 0,
         paddingVertical: 0,
         margin: 0,
+        fontFamily: customFont,
     },
 });


### PR DESCRIPTION
## 이 PR이 하는 일
일기 작성 및 감정 선택 기능 통합 구현, 커스텀 디자인 알림 적용

## 설명
- 이제부터 DiaryEditor 컴포넌트는 사용하지 않고 EmotionSelector로 통합
- 제목 입력, 내용 작성, 감정 설정을 한 화면에서 처리
- 기존 감정 선택 기능 유지
- 실시간 감정 위치 업데이트로 감정 선택된 텍스트의 위치 실시간 보정
- 감정이 설정된 텍스트 삭제 시 사용자 경고 기능 추가
- 저장하지 않고 페이지 이탈 시 경고 알림 구현
- 키보드 활성화 시 감정 통계 영역 자동 숨김
- 감정을 하나도 선택하지 않았을 때의 경고 기능 추가
- 모든 페이지의 알림을 커스텀 디자인 알림(Alert)으로 적용

<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/b44eafc7-f2a0-4e64-a075-c0871ab5519d" />
<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/0e543b2b-279b-4ad6-bc49-a061ba90ee57" />
<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/c59d7e9c-28c4-4d46-9ea5-6ec30e1cc4c1" />